### PR TITLE
adds dmg to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
           "squirrel"
         ],
         "darwin": [
-          "zip"
+          "zip",
+          "dmg"
         ],
         "linux": [
           "deb"


### PR DESCRIPTION
Adds `.dmg` to `package.json`, so on packaging for OSX you get `.zip` and `.dmg` files